### PR TITLE
Added build.zig.zon to make possible auto fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Zig binding for a tiny cross-platform **webview** library to build modern cross-
    - [WebKit](https://webkit.org/)
 
 ### Usage
+#### Auto
+```
+zig fetch --save https://github.com/thechampagne/webview-zig/archive/refs/heads/main.tar.gz
+```
+#### Manual
 `build.zig.zon`:
 ```zig
 .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,6 @@
+.{
+    .name = "webview",
+    .version = "1.0.0",
+    .dependencies = .{},
+    .paths = .{ "build.zig", "build.zig.zon", "src", "external" },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,12 @@
 .{
     .name = "webview",
-    .version = "1.0.0",
-    .dependencies = .{},
-    .paths = .{ 
+    .version = "0.1.0",
+    .paths = .{
+        "LICENSE",
+        ".gitignore",
+        ".gitattributes",
+        "README.md",
+        "examples"
         "build.zig",
         "build.zig.zon", 
         "src", 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,5 +2,10 @@
     .name = "webview",
     .version = "1.0.0",
     .dependencies = .{},
-    .paths = .{ "build.zig", "build.zig.zon", "src", "external" },
+    .paths = .{ 
+        "build.zig",
+        "build.zig.zon", 
+        "src", 
+        "external",
+    },
 }


### PR DESCRIPTION
When this file is added, it's possible use the command "zig fetch" instead to insert manually the hash on build.zig.zon.
![image](https://github.com/thechampagne/webview-zig/assets/64230454/ea104ca7-cd12-4f73-b960-212bdbe6cf91)
