### PR TITLE
Add nested comment for README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const webview = b.dependency("webview", .{
 });
 exe.root_module.addImport("webview", webview.module("webview"));
 exe.linkLibrary(webview.artifact("webviewStatic")); // or "webviewShared" for shared library
-// exe.linkSystemLibrary("webview"); to link with installed prebuilt library without building
+// exe.linkSystemLibrary("webview"); // to link with installed prebuilt library without building
 ```
 
 ### References


### PR DESCRIPTION
Uncommenting the README.md line at https://github.com/thechampagne/webview-zig/blob/main/README.md?plain=1#L45 without adding the nested comment turns into a syntax error.
With a `//` after the `;` the line can be uncommented freely