### PR TITLE
update to 0.14.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,9 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    
+
     const webview = b.dependency("webview", .{});
 
     const webviewRaw = b.addTranslateC(.{
@@ -12,7 +11,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .target = target,
     }).createModule();
-    
+
     _ = b.addModule("webview", .{
         .root_source_file = b.path("src/webview.zig"),
         //.dependencies = &[_]std.Build.ModuleDependency{},
@@ -53,7 +52,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
     });
     staticLib.addIncludePath(webview.path("core/include/webview/"));
-    staticLib.defineCMacro("WEBVIEW_STATIC", null);
+    staticLib.root_module.addCMacro("WEBVIEW_STATIC", "");
     staticLib.linkLibCpp();
     switch (target.query.os_tag orelse @import("builtin").os.tag) {
         .windows => {
@@ -99,7 +98,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
     });
     sharedLib.addIncludePath(webview.path("core/include/webview/"));
-    sharedLib.defineCMacro("WEBVIEW_BUILD_SHARED", null);
+    staticLib.root_module.addCMacro("WEBVIEW_BUILD_SHARED", "");
     sharedLib.linkLibCpp();
     switch (target.query.os_tag orelse @import("builtin").os.tag) {
         .windows => {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "webview",
+    .name = .webview,
     .version = "0.1.0",
+    .fingerprint = 0xd0d1ff8da6749a23,
     .dependencies = .{
         .webview = .{
             .url = "https://github.com/webview/webview/archive/refs/tags/0.12.0.tar.gz",
@@ -12,8 +13,8 @@
         "README.md",
         "examples",
         "build.zig",
-        "build.zig.zon", 
-        "src", 
+        "build.zig.zon",
+        "src",
         "external",
     },
 }


### PR DESCRIPTION
The current repository encountered an error when attempting to compile at version 0.14.0:

```shell
error: no field or member function named 'defineCMacro' in 'Build.Step.Compile'
staticLib.defineCMacro("WEBVIEW_STATIC", null);
```

[defineCMacro has been removed](https://github.com/ziglang/zig/pull/20388#issuecomment-2586001092), `defineCMacro` should be replaced with:

```zig
staticLib.root_module.addCMacro("WEBVIEW_STATIC", "");
```

Additionally, build.zig.zon has been handled according to the following changes, see [New Package Hash Format](https://ziglang.org/download/0.14.0/release-notes.html#toc-New-Package-Hash-Format)

- `name` must be a valid bare Zig-identifier.

- new `fingerprint` field

It is worth noting that the new [addLibrary Function](https://ziglang.org/download/0.14.0/release-notes.html#toc-addLibrary-Function) has replaced the original `addStaticLibrary` and `addSharedLibrary`, as I am not familiar with this part and these two functions have not been fully deprecated in version 0.14.0, so I have not handled them.