### PR TITLE
Update from deprecrated WebKitGTK dependency to 4.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -84,12 +84,12 @@ pub fn build(b: *std.Build) void {
             staticLib.addIncludePath(.{ .cwd_relative = "/usr/local/include/atk-1.0/" });
             staticLib.addIncludePath(.{ .cwd_relative = "/usr/local/include/libsoup-3.0/" });
             staticLib.linkSystemLibrary("gtk-3");
-            staticLib.linkSystemLibrary("webkit2gtk-4.0");
+            staticLib.linkSystemLibrary("webkit2gtk-4.1");
         },
         else => {
             staticLib.addCSourceFile(.{ .file = webview.path("core/src/webview.cc"), .flags = &.{"-std=c++11"} });
             staticLib.linkSystemLibrary("gtk+-3.0");
-            staticLib.linkSystemLibrary("webkit2gtk-4.0");
+            staticLib.linkSystemLibrary("webkit2gtk-4.1");
         },
     }
     b.installArtifact(staticLib);
@@ -133,12 +133,12 @@ pub fn build(b: *std.Build) void {
             sharedLib.addIncludePath(.{ .cwd_relative = "/usr/local/include/atk-1.0/" });
             sharedLib.addIncludePath(.{ .cwd_relative = "/usr/local/include/libsoup-3.0/" });
             sharedLib.linkSystemLibrary("gtk-3");
-            sharedLib.linkSystemLibrary("webkit2gtk-4.0");
+            sharedLib.linkSystemLibrary("webkit2gtk-4.1");
         },
         else => {
             sharedLib.addCSourceFile(.{ .file = webview.path("core/src/webview.cc"), .flags = &.{"-std=c++11"} });
             sharedLib.linkSystemLibrary("gtk+-3.0");
-            sharedLib.linkSystemLibrary("webkit2gtk-4.0");
+            sharedLib.linkSystemLibrary("webkit2gtk-4.1");
         },
     }
     b.installArtifact(sharedLib);


### PR DESCRIPTION
The current backend for both Linux and FreeBSD is GTK3 with WebKitGTK 4.0, however, this version of WebKitGTK has been deprecated and it is no longer available in the official repositories of some Linux distributions (like Fedora).

https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version

Webview already supports WebKitGTK version 4.1, so the dependency can be switched really easily. This PR changes `build.zig` to update the dependency. I've already tested this change on my Fedora machine and it works fine.